### PR TITLE
Add AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Auditor Instructions
+
+This repository contains the telcoin-network Rust code and Solidity tn-contracts. Follow these guidelines when creating audit reports. Avoid modifying repository code unless a task specifically calls for it.
+
+- **Findings Formatting**: When submitting a finding, include Severity (High, Medium, Low, Information), Likelihood score, Impact score, and a short Finding Title.
+- Use the following template for findings:
+  ## Summary
+  A short summary of the issue, keep it brief.
+
+  ## Finding Description
+  A more detailed explanation of the issue. Poorly written or incorrect findings may result in rejection and a decrease of reputation score.
+
+  Describe which security guarantees it breaks and how it breaks them. If this bug does not automatically happen, showcase how a malicious input would propagate through the system to the part of the code where the issue occurs.
+
+  ## Impact Explanation
+  Elaborate on why you've chosen a particular impact assessment.
+
+  ## Likelihood Explanation
+  Explain how likely this is to occur and why.
+
+  ## Proof of Concept
+  A proof of concept is normally required for Critical, High and Medium submissions for reviewers under 80 reputation points. Please check the competition page for more details, otherwise your submission may be rejected by the judges.
+
+  ## Recommendation
+  How can the issue be fixed or solved. Preferably, you can also add a snippet of the fixed code here.
+
+- **Testing Requirements**: After modifying code, run all provided tests.
+- Use `cargo test --all` for the Rust code and `forge test` for Solidity contracts.


### PR DESCRIPTION
## Summary
- add AGENTS.md with instructions for auditors
- clarify that code should not be modified unless required

## Testing
- `cargo test --all` *(fails: could not compile `tn-config`)*
- `forge test` *(fails: `forge` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685980bfc1048323a17323b4b09ea860